### PR TITLE
move trust function into limelight class, and change ip back to .11 to match docs

### DIFF
--- a/vision/Limelight.java
+++ b/vision/Limelight.java
@@ -64,7 +64,7 @@ public class Limelight {
      * @see Limelight#Limelight(String, String)
      */
     public Limelight(String name) {
-        this(name, "10.8.62.12");
+        this(name, "10.8.62.11");
     }
 
     /**
@@ -590,5 +590,23 @@ public class Limelight {
             e.printStackTrace();
             return null;
         }
+    }
+
+    /**
+     * Current checks:
+     * <ul>
+     * <li> Pose is not null </li>
+     * <li> Pose is not an empty Pose4d </li>
+     * <li> Limelight has a target </li>
+     * </ul>
+     * @return true if all checks pass, otherwise false
+     */
+    public boolean trustPose() {
+        Pose4d pose = getAlliancePose();
+        return (
+            pose != null &&
+            pose != new Pose4d() &&
+            hasTarget()
+        );
     }
 }

--- a/vision/Limelight.java
+++ b/vision/Limelight.java
@@ -9,6 +9,7 @@ import java.net.MalformedURLException;
 import java.net.SocketException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
@@ -608,5 +609,21 @@ public class Limelight {
             pose != new Pose4d() &&
             hasTarget()
         );
+    }
+
+    /**
+     * @param limelights an array containing all limelights to filter
+     * @return an array containing only the limelights that pass the trustPose() check
+     */
+    public static Limelight[] filterLimelights(Limelight[] limelights) {
+        Limelight[] out = {};
+        for (Limelight limelight : limelights) {
+            if(limelight.trustPose()) {
+                out = Arrays.copyOf(out, out.length + 1);
+                out[out.length-1] = limelight;
+            }
+        }
+
+        return out;
     }
 }


### PR DESCRIPTION
apologies for my spelling lol

this method shouldn't' have been in Swerve.java in the first place, and moving it is one of the first steps to have multiple limelights

I intend to add some more tests to the trust function as we learn more, eg limit how far away targets can be, etc