### PR TITLE
Add timestamp to pose object, will default to current time if missing

### DIFF
--- a/util/Pose4d.java
+++ b/util/Pose4d.java
@@ -3,8 +3,10 @@ package frc.thunder.util;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Translation3d;
+import edu.wpi.first.wpilibj.Timer;
 
 public class Pose4d extends Pose3d {
+    double timestamp;
     double latency;
 
     public Pose4d() {
@@ -15,9 +17,19 @@ public class Pose4d extends Pose3d {
     /**
      * In general, translation units should be meters (but other units can work)
      */
+    public Pose4d(Translation3d translation, Rotation3d rotation, double latency, double timestamp) {
+        super(translation, rotation);
+        this.latency = latency;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * In general, translation units should be meters (but other units can work)
+     */
     public Pose4d(Translation3d translation, Rotation3d rotation, double latency) {
         super(translation, rotation);
         this.latency = latency;
+        this.timestamp = Timer.getFPGATimestamp();
     }
 
     /**
@@ -28,11 +40,23 @@ public class Pose4d extends Pose3d {
         this(new Translation3d(x, y, z), new Rotation3d(yaw, pitch, roll), latency);
     }
 
+    /**
+     * In general, translation units should be meters (but other units can work)
+     * Rotation units must be radians
+     */
+    public Pose4d(double x, double y, double z, double yaw, double pitch, double roll, double latency, double timestamp) {
+        this(new Translation3d(x, y, z), new Rotation3d(yaw, pitch, roll), latency, timestamp);
+    }
+
     public double getLatency() {
         return latency;
     }
 
     public void setLatency(double latency) {
         this.latency = latency;
+    }
+
+    public double getFPGATimestamp() {
+        return timestamp - latency;
     }
 }

--- a/util/PoseConverter.java
+++ b/util/PoseConverter.java
@@ -23,6 +23,19 @@ public class PoseConverter {
     }
 
     /**
+     * Convert an array of 7 doubles to a Pose4d
+     * @param ntValues array of 7 doubles containing translation (X,Y,Z) Rotation(Roll,Pitch,Yaw), total latency (cl+tl)
+     * @return a new Pose4d object with the values from the array
+     */
+    public static Pose4d toPose4d(double[] ntValues, double timestamp) {
+        if (ntValues.length == 7){
+            return new Pose4d(new Translation3d(ntValues[0], ntValues[1], ntValues[2]), new Rotation3d(Math.toRadians(ntValues[3]), Math.toRadians(ntValues[4]), Math.toRadians(ntValues[5])), ntValues[6], timestamp);
+        } else {
+            return new Pose4d();
+        }
+    }
+
+    /**
      * Convert an array of 6 doubles to a Pose3d
      * @param ntValues array of 6 doubles containing translation (X,Y,Z) Rotation(Roll,Pitch,Yaw)
      * @return a new Pose3d object with the values from the array

--- a/vision/Limelight.java
+++ b/vision/Limelight.java
@@ -639,16 +639,15 @@ public class Limelight {
      */
     public boolean trustPose() {
         Pose4d pose = getAlliancePose();
+        return hasTarget() && trustPose(pose);
+    }
+
+    static RectangularRegionConstraint FIELD = new RectangularRegionConstraint(new Translation2d(0, 0), VisionConstants.FIELD_LIMIT, null);
+    public static boolean trustPose(Pose4d pose) {
         return (
             pose != null &&
             pose != new Pose4d() &&
-            hasTarget() &&
-            //Ensure reported pose is on the field
-            new RectangularRegionConstraint(
-                new Translation2d(0, 0),
-                VisionConstants.FIELD_LIMIT,
-                null
-            ).isPoseInRegion(pose.toPose2d())
+            FIELD.isPoseInRegion(pose.toPose2d())
         );
     }
 
@@ -666,5 +665,15 @@ public class Limelight {
         }
 
         return out;
+    }
+
+    /**
+     * prevent race condition where we will get incorrect poses -- also should be more efficent
+     * 
+     * @param limelights an array containing all limelights to filter
+     * @return an array containing only the Pose4d objects that pass the trustPose() check
+     */
+    public static Pose4d[] filteredPoses(Limelight[] limelights) {
+        return (Pose4d[]) Arrays.stream(limelights).map(l -> l.getAlliancePose()).filter(p -> trustPose(p)).toArray();
     }
 }

--- a/vision/Limelight.java
+++ b/vision/Limelight.java
@@ -28,6 +28,7 @@ import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.TimestampedDoubleArray;
 import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.Timer;
 import frc.robot.Constants.VisionConstants;
 import frc.thunder.util.Pose4d;
 import frc.thunder.util.PoseConverter;
@@ -647,7 +648,8 @@ public class Limelight {
         return (
             pose != null &&
             pose != new Pose4d() &&
-            FIELD.isPoseInRegion(pose.toPose2d())
+            FIELD.isPoseInRegion(pose.toPose2d()) &&
+            (Timer.getFPGATimestamp() - pose.getFPGATimestamp() < 0.03)
         );
     }
 

--- a/vision/Limelight.java
+++ b/vision/Limelight.java
@@ -237,7 +237,12 @@ public class Limelight {
     }
 
     DoubleArrayEntry poseEntry = null;
-
+    /**
+     * This function only does the lookup, once which should be slightly more
+     * efficient.
+     * 
+     * @return the Network Table Entry for the pose, based on current alliance
+     */
     private DoubleArrayEntry getPoseEntry() {
         if (poseEntry != null) return poseEntry;
 


### PR DESCRIPTION
Adds an optional timestamp to the Pose4d object -- this allows it to be captured when read from a network table, and used in the pose estimator.

Added a method to get the filtered poses, this is to prevent the case where we verify the pose, and then a new "bad" entry comes in behind it, which we then accept.

